### PR TITLE
set X-Plasma-API-Minimum-Version to 6 in metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,5 +22,6 @@
     ],
     "X-Plasma-RequiredExtensions": [
         "LaunchApp"
-    ]
+    ],
+    "X-Plasma-API-Minimum-Version": "6.0"
 }


### PR DESCRIPTION
Without X-Plasma-API-Minimum-Version tag plasma see the plasmoid as incompatible with plasma 6