### PR TITLE
Fix missing Favorite add/remove in context menu

### DIFF
--- a/contents/ui/AbstractKickoffItemDelegate.qml
+++ b/contents/ui/AbstractKickoffItemDelegate.qml
@@ -58,7 +58,7 @@ T.ItemDelegate {
     function openActionMenu(x = undefined, y = undefined) {
         if (!hasActionList) { return; }
 
-        let actions = model.actionList;
+        let actions = Array.from(model.actionList);
         const favoriteActions = Tools.createFavoriteActions(
             i18n, //i18n() function callback
             view.model.favoritesModel,


### PR DESCRIPTION
Update AbstractKickoffItemDelegate.qml, model.actionList -> Array.from(model.actionList). Looked it up from the original Kickoff. Fixed issue #15 